### PR TITLE
chore: update to zig 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 zig-cache/
+.zig-cache/
 zig-out/
 .zigmod
 deps.zig

--- a/build.zig
+++ b/build.zig
@@ -1,18 +1,18 @@
 const std = @import("std");
 
-pub fn build(b: *std.build) void {
+pub fn build(b: *std.Build) void {
     // Standard optimize option allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    _ = b.addModule("btreemap", .{ //
-        .source_file = .{ .path = "src/btreemap.zig" },
+    _ = b.addModule("btreemap", .{
+        .root_source_file = b.path("src/btreemap.zig"),
     });
 
-    const main_tests = b.addTest(.{ //
+    const main_tests = b.addTest(.{
         .name = "zig btreemap tests",
-        .root_source_file = .{ .path = "src/btreemap.zig" },
+        .root_source_file = b.path("src/btreemap.zig"),
         .target = target,
         .optimize = optimize,
     });


### PR DESCRIPTION
This patch makes `zig build` and `zig build test` succeed with zig version 0.13.0